### PR TITLE
修复png图片透明背景压缩后变黑的问题。

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,1 +1,0 @@
-PictureSelector

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -156,14 +156,11 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8 (3)" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="JDK" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">
     <option name="id" value="Android" />
-  </component>
-  <component name="SvnConfiguration" myUseAcceleration="nothing">
-    <configuration useDefault="false">$USER_HOME$/.subversion</configuration>
   </component>
   <component name="masterDetails">
     <states>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,9 +2,13 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
+      <module fileurl="file://$PROJECT_DIR$/MyPictureSelector.iml" filepath="$PROJECT_DIR$/MyPictureSelector.iml" />
       <module fileurl="file://$PROJECT_DIR$/PictureSelector.iml" filepath="$PROJECT_DIR$/PictureSelector.iml" />
       <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
+      <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
       <module fileurl="file://$PROJECT_DIR$/picture_library/picture_library.iml" filepath="$PROJECT_DIR$/picture_library/picture_library.iml" />
+      <module fileurl="file://$PROJECT_DIR$/picture_library/picture_library.iml" filepath="$PROJECT_DIR$/picture_library/picture_library.iml" />
+      <module fileurl="file://$PROJECT_DIR$/ucrop/ucrop.iml" filepath="$PROJECT_DIR$/ucrop/ucrop.iml" />
       <module fileurl="file://$PROJECT_DIR$/ucrop/ucrop.iml" filepath="$PROJECT_DIR$/ucrop/ucrop.iml" />
     </modules>
   </component>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.3"
 
     defaultConfig {
         applicationId "com.luck.pictureselector"
         minSdkVersion 14
-        targetSdkVersion 23
+        targetSdkVersion 25
         versionCode 5
         versionName "2.0.5"
     }

--- a/picture_library/build.gradle
+++ b/picture_library/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
+    compileSdkVersion 25
     buildToolsVersion "25.0.3"
 
     defaultConfig {
-        minSdkVersion 10
-        targetSdkVersion 23
+        minSdkVersion 14
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
     }
@@ -22,8 +22,8 @@ android {
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     compile project(':ucrop')
-    compile 'com.android.support:appcompat-v7:23.4.0'
-    compile 'com.android.support:recyclerview-v7:23.4.0'
+    compile 'com.android.support:appcompat-v7:25.3.1'
+    compile 'com.android.support:recyclerview-v7:25.3.1'
     compile 'com.github.bumptech.glide:glide:4.0.0'
     compile 'io.reactivex.rxjava2:rxjava:2.0.5'
     compile 'io.reactivex.rxjava2:rxandroid:2.0.1'

--- a/picture_library/src/main/java/com/luck/picture/lib/compress/CompressImageUtil.java
+++ b/picture_library/src/main/java/com/luck/picture/lib/compress/CompressImageUtil.java
@@ -6,6 +6,7 @@ import android.graphics.Bitmap.Config;
 import android.graphics.BitmapFactory;
 import android.os.Handler;
 
+import com.luck.picture.lib.tools.FileExtensionUtils;
 import com.luck.picture.lib.tools.PictureFileUtils;
 
 import java.io.ByteArrayOutputStream;
@@ -62,12 +63,19 @@ public class CompressImageUtil {
                 // TODO Auto-generated method stub
                 ByteArrayOutputStream baos = new ByteArrayOutputStream();
                 int options = 100;
-                bitmap.compress(Bitmap.CompressFormat.JPEG, options, baos);//质量压缩方法，把压缩后的数据存放到baos中 (100表示不压缩，0表示压缩到最小)
+                Bitmap.CompressFormat compressFormat;
+                if (FileExtensionUtils.getFileExtension(imgPath).equals("png")){
+                    compressFormat = Bitmap.CompressFormat.PNG;
+                }else {
+                    compressFormat = Bitmap.CompressFormat.JPEG;
+                }
+
+                bitmap.compress(compressFormat, options, baos);//质量压缩方法，把压缩后的数据存放到baos中 (100表示不压缩，0表示压缩到最小)
                 while (baos.toByteArray().length > config.getMaxSize()) {//循环判断如果压缩后图片是否大于指定大小,大于继续压缩
                     baos.reset();//重置baos即让下一次的写入覆盖之前的内容
                     options -= 5;//图片质量每次减少5
                     if (options <= 5) options = 5;//如果图片质量小于5，为保证压缩后的图片质量，图片最底压缩质量为5
-                    bitmap.compress(Bitmap.CompressFormat.JPEG, options, baos);//将压缩后的图片保存到baos中
+                    bitmap.compress(compressFormat, options, baos);//将压缩后的图片保存到baos中
                     if (options == 5) break;//如果图片的质量已降到最低则，不再进行压缩
                 }
 //				if(bitmap!=null&&!bitmap.isRecycled()){
@@ -124,8 +132,16 @@ public class CompressImageUtil {
         if (config.isEnableQualityCompress()) {
             compressImageByQuality(bitmap, imgPath, listener);//压缩好比例大小后再进行质量压缩
         } else {
+
+            Bitmap.CompressFormat compressFormat;
+            if (FileExtensionUtils.getFileExtension(imgPath).equals("png")){
+                compressFormat = Bitmap.CompressFormat.PNG;
+            }else {
+                compressFormat = Bitmap.CompressFormat.JPEG;
+            }
+
             File thumbnailFile = getThumbnailFile(new File(imgPath));
-            bitmap.compress(Bitmap.CompressFormat.JPEG, 100, new FileOutputStream(thumbnailFile));
+            bitmap.compress(compressFormat, 100, new FileOutputStream(thumbnailFile));
 
             listener.onCompressSuccess(thumbnailFile.getPath());
         }

--- a/picture_library/src/main/java/com/luck/picture/lib/compress/LubanCompresser.java
+++ b/picture_library/src/main/java/com/luck/picture/lib/compress/LubanCompresser.java
@@ -7,6 +7,7 @@ import android.media.ExifInterface;
 import android.support.annotation.NonNull;
 
 import com.luck.picture.lib.config.PictureMimeType;
+import com.luck.picture.lib.tools.FileExtensionUtils;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -386,12 +387,20 @@ class LubanCompresser {
         }
 
         int options = 100;
-        bitmap.compress(mLuban.compressFormat, options, mByteArrayOutputStream);
+
+        Bitmap.CompressFormat compressFormat;
+        if (FileExtensionUtils.getFileExtension(filePath).equals("png")) {
+            compressFormat = Bitmap.CompressFormat.PNG;
+        } else {
+            compressFormat = mLuban.compressFormat;
+        }
+
+        bitmap.compress(compressFormat, options, mByteArrayOutputStream);
 
         while (mByteArrayOutputStream.size() / 1024 > size && options > 6) {
             mByteArrayOutputStream.reset();
             options -= 6;
-            bitmap.compress(mLuban.compressFormat, options, mByteArrayOutputStream);
+            bitmap.compress(compressFormat, options, mByteArrayOutputStream);
         }
         bitmap.recycle();
 

--- a/picture_library/src/main/java/com/luck/picture/lib/tools/FileExtensionUtils.java
+++ b/picture_library/src/main/java/com/luck/picture/lib/tools/FileExtensionUtils.java
@@ -1,0 +1,29 @@
+package com.luck.picture.lib.tools;
+
+import android.text.TextUtils;
+
+import java.io.File;
+
+/**
+ * Created by xiaosong on 2017/10/28.
+ */
+
+public class FileExtensionUtils {
+
+    /**
+     * 获取文件后缀名
+     * @param filePath
+     * @return
+     */
+    public static String getFileExtension(String filePath) {
+        if (TextUtils.isEmpty(filePath)) {
+            return filePath;
+        }
+        int extenPosi = filePath.lastIndexOf(".");
+        int filePosi = filePath.lastIndexOf(File.separator);
+        if (extenPosi == -1) {
+            return "";
+        }
+        return (filePosi >= extenPosi) ? "" : filePath.substring(extenPosi + 1);
+    }
+}

--- a/ucrop/build.gradle
+++ b/ucrop/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
+    compileSdkVersion 25
     buildToolsVersion '25.0.3'
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 23
+        targetSdkVersion 25
         versionCode 22
         versionName "2.2.0-native"
 
@@ -31,7 +31,7 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:23.4.0'
-    compile 'com.android.support:recyclerview-v7:23.4.0'
+    compile 'com.android.support:appcompat-v7:25.3.1'
+    compile 'com.android.support:recyclerview-v7:25.3.1'
     compile 'com.github.bumptech.glide:glide:4.0.0'
 }


### PR DESCRIPTION
通过后缀名区分png格式的图片，防止格式指定错误，导致压缩后透明位置变黑。