### PR TITLE
将 PictureExternalPreviewActivity 主题风格与主题配置的预览风格相一致

### DIFF
--- a/picture_library/src/main/res/layout/picture_activity_external_preview.xml
+++ b/picture_library/src/main/res/layout/picture_activity_external_preview.xml
@@ -9,7 +9,7 @@
         android:id="@+id/rl_title"
         android:layout_width="match_parent"
         android:layout_height="48dp"
-        android:background="@color/bar_grey">
+        android:background="?attr/picture.ac_preview.title.bg">
 
         <ImageButton
             android:id="@+id/left_back"
@@ -17,7 +17,7 @@
             android:layout_height="match_parent"
             android:layout_centerVertical="true"
             android:background="@color/transparent"
-            android:src="@drawable/picture_back"
+            android:src="?attr/picture.preview.leftBack.icon"
             android:visibility="visible" />
 
         <TextView
@@ -28,7 +28,7 @@
             android:layout_centerVertical="true"
             android:ellipsize="end"
             android:maxEms="11"
-            android:textColor="@color/white"
+            android:textColor="?attr/picture.ac_preview.title.textColor"
             android:textSize="18sp" />
 
     </RelativeLayout>


### PR DESCRIPTION
当修改主题颜色配置时，将 PictureExrernalPreviewActivity 标题栏的颜色与主题整体的预览风格相统一。