### PR TITLE
 混选模式下出现长度超出

### DIFF
--- a/picture_library/src/main/java/com/luck/picture/lib/PicturePreviewActivity.java
+++ b/picture_library/src/main/java/com/luck/picture/lib/PicturePreviewActivity.java
@@ -606,11 +606,15 @@ public class PicturePreviewActivity extends PictureBaseActivity implements
             if (config.isWithVideoImage) {
                 // 混选模式
                 int videoSize = 0;
+                int imageSize = 0;
                 for (int i = 0; i < currentSize; i++) {
                     LocalMedia media = selectData.get(i);
                     if (PictureMimeType.isHasVideo(media.getMimeType())) {
                         videoSize++;
                     }
+                    if (PictureMimeType.isHasImage(media.getMimeType())) {
+                         imageSize++;
+                    }    
                 }
                 if (image != null && PictureMimeType.isHasVideo(image.getMimeType())) {
                     if (config.maxVideoSelectNum <= 0) {
@@ -619,7 +623,7 @@ public class PicturePreviewActivity extends PictureBaseActivity implements
                         return;
                     }
 
-                    if (selectData.size() >= config.maxSelectNum && !check.isSelected()) {
+                    if (imageSize >= config.maxSelectNum && !check.isSelected()) {
                         showPromptDialog(getString(R.string.picture_message_max_num, config.maxSelectNum));
                         return;
                     }

--- a/picture_library/src/main/java/com/luck/picture/lib/adapter/PictureImageGridAdapter.java
+++ b/picture_library/src/main/java/com/luck/picture/lib/adapter/PictureImageGridAdapter.java
@@ -416,10 +416,14 @@ public class PictureImageGridAdapter extends RecyclerView.Adapter<RecyclerView.V
         if (config.isWithVideoImage) {
             // isWithVideoImage mode
             int videoSize = 0;
+            int imageSize = 0;
             for (int i = 0; i < count; i++) {
                 LocalMedia media = selectData.get(i);
                 if (PictureMimeType.isHasVideo(media.getMimeType())) {
                     videoSize++;
+                }
+                if (PictureMimeType.isHasImage(media.getMimeType())) {
+                    imageSize++;
                 }
             }
 
@@ -429,7 +433,7 @@ public class PictureImageGridAdapter extends RecyclerView.Adapter<RecyclerView.V
                     return;
                 }
 
-                if (getSelectedSize() >= config.maxSelectNum && !isChecked) {
+                if (imageSize >= config.maxSelectNum && !isChecked) {
                     showPromptDialog(context.getString(R.string.picture_message_max_num, config.maxSelectNum));
                     return;
                 }


### PR DESCRIPTION
混选模式下,判断图片选择长度不能用数组的总长度来判定。
例如我图片定义7张 视频定义3个 我选择了3个视频然后图片选择到第6张则会提示我图片已经超出最大选择数量
