### PR TITLE
增加是否显示不符合时长要求的视频的设置项

### DIFF
--- a/picture_library/src/main/java/com/luck/picture/lib/PictureSelectionModel.java
+++ b/picture_library/src/main/java/com/luck/picture/lib/PictureSelectionModel.java
@@ -1465,4 +1465,14 @@ public class PictureSelectionModel {
             throw new NullPointerException("This PictureSelector is Null");
         }
     }
+
+    /**
+     * @param show whether to show too long and too short videos
+     * @return
+     */
+    public PictureSelectionModel isShowOutLengthVideos(boolean show) {
+        selectionConfig.showOutLengthVideos = show;
+        return this;
+    }
+
 }

--- a/picture_library/src/main/java/com/luck/picture/lib/config/PictureSelectionConfig.java
+++ b/picture_library/src/main/java/com/luck/picture/lib/config/PictureSelectionConfig.java
@@ -156,6 +156,7 @@ public final class PictureSelectionConfig implements Parcelable {
     public boolean isAndroidQChangeWH;
     public boolean isAndroidQChangeVideoWH;
     public boolean isQuickCapture;
+    public boolean showOutLengthVideos;
     /**
      * 内测专用###########
      */
@@ -265,6 +266,7 @@ public final class PictureSelectionConfig implements Parcelable {
         isAndroidQChangeWH = true;
         isAndroidQChangeVideoWH = false;
         isQuickCapture = true;
+        showOutLengthVideos = false;
     }
 
     public static PictureSelectionConfig getInstance() {
@@ -404,6 +406,7 @@ public final class PictureSelectionConfig implements Parcelable {
         dest.writeByte(this.isFallbackVersion ? (byte) 1 : (byte) 0);
         dest.writeByte(this.isFallbackVersion2 ? (byte) 1 : (byte) 0);
         dest.writeByte(this.isFallbackVersion3 ? (byte) 1 : (byte) 0);
+        dest.writeByte(this.showOutLengthVideos ? (byte) 1 : (byte) 0);
     }
 
     protected PictureSelectionConfig(Parcel in) {
@@ -508,6 +511,7 @@ public final class PictureSelectionConfig implements Parcelable {
         this.isFallbackVersion = in.readByte() != 0;
         this.isFallbackVersion2 = in.readByte() != 0;
         this.isFallbackVersion3 = in.readByte() != 0;
+        this.showOutLengthVideos = in.readByte() != 0;
     }
 
     public static final Creator<PictureSelectionConfig> CREATOR = new Creator<PictureSelectionConfig>() {

--- a/picture_library/src/main/java/com/luck/picture/lib/model/LocalMediaLoader.java
+++ b/picture_library/src/main/java/com/luck/picture/lib/model/LocalMediaLoader.java
@@ -394,13 +394,14 @@ public final class LocalMediaLoader {
      * @return
      */
     private String getDurationCondition(long exMaxLimit, long exMinLimit) {
-        long maxS = config.videoMaxSecond == 0 ? Long.MAX_VALUE : config.videoMaxSecond;
+        long maxS = config.videoMaxSecond;
+        maxS = ( maxS == 0 || (maxS != 0 && config.showOutLengthVideos)) ? Long.MAX_VALUE : config.videoMaxSecond;
         if (exMaxLimit != 0) {
             maxS = Math.min(maxS, exMaxLimit);
         }
         return String.format(Locale.CHINA, "%d <%s " + MediaStore.MediaColumns.DURATION + " and " + MediaStore.MediaColumns.DURATION + " <= %d",
-                Math.max(exMinLimit, config.videoMinSecond),
-                Math.max(exMinLimit, config.videoMinSecond) == 0 ? "" : "=",
+                config.showOutLengthVideos? 0:Math.max(exMinLimit, config.videoMinSecond),
+                Math.max(exMinLimit, config.videoMinSecond) == 0 || (Math.max(exMinLimit, config.videoMinSecond) != 0 && config.showOutLengthVideos) ? "" : "=",
                 maxS);
     }
 

--- a/picture_library/src/main/java/com/luck/picture/lib/model/LocalMediaPageLoader.java
+++ b/picture_library/src/main/java/com/luck/picture/lib/model/LocalMediaPageLoader.java
@@ -333,11 +333,11 @@ public final class LocalMediaPageLoader {
                                     }
                                 }
                                 if (PictureMimeType.isHasVideo(mimeType)) {
-                                    if (config.videoMinSecond > 0 && duration < config.videoMinSecond) {
+                                    if (config.videoMinSecond > 0 && duration < config.videoMinSecond && !config.showOutLengthVideos) {
                                         // If you set the minimum number of seconds of video to display
                                         continue;
                                     }
-                                    if (config.videoMaxSecond > 0 && duration > config.videoMaxSecond) {
+                                    if (config.videoMaxSecond > 0 && duration > config.videoMaxSecond && !config.showOutLengthVideos) {
                                         // If you set the maximum number of seconds of video to display
                                         continue;
                                     }
@@ -697,13 +697,15 @@ public final class LocalMediaPageLoader {
      * @return
      */
     private String getDurationCondition(long exMaxLimit, long exMinLimit) {
-        long maxS = config.videoMaxSecond == 0 ? Long.MAX_VALUE : config.videoMaxSecond;
+        long maxS = config.videoMaxSecond;
+        maxS = ( maxS == 0 || (maxS != 0 && config.showOutLengthVideos)) ? Long.MAX_VALUE : config.videoMaxSecond;
         if (exMaxLimit != 0) {
             maxS = Math.min(maxS, exMaxLimit);
         }
+
         return String.format(Locale.CHINA, "%d <%s " + MediaStore.MediaColumns.DURATION + " and " + MediaStore.MediaColumns.DURATION + " <= %d",
-                Math.max(exMinLimit, config.videoMinSecond),
-                Math.max(exMinLimit, config.videoMinSecond) == 0 ? "" : "=",
+                config.showOutLengthVideos? 0:Math.max(exMinLimit, config.videoMinSecond),
+                Math.max(exMinLimit, config.videoMinSecond) == 0 || (Math.max(exMinLimit, config.videoMinSecond) != 0 && config.showOutLengthVideos) ? "" : "=",
                 maxS);
     }
 


### PR DESCRIPTION
目前框架里虽然能设置视频长度筛选，但是进入选择列表后会直接把不符合要求的视频过滤掉，显得很突兀。所以我添加了设置是否在选择列表里显示不符合时长要求的视频设置项。