### PR TITLE
查看大图时 开放容器photoview 方便外部设置它的触摸事件

### DIFF
--- a/app/src/main/java/com/luck/pictureselector/CoilEngine.kt
+++ b/app/src/main/java/com/luck/pictureselector/CoilEngine.kt
@@ -33,6 +33,7 @@ class CoilEngine : ImageEngine {
         url: String,
         maxWidth: Int,
         maxHeight: Int,
+        imageView: ImageView?,
         call: OnCallbackListener<Bitmap>?
     ) {
         if (!ActivityCompatHelper.assertValidRequest(context)) {

--- a/app/src/main/java/com/luck/pictureselector/GlideEngine.java
+++ b/app/src/main/java/com/luck/pictureselector/GlideEngine.java
@@ -51,7 +51,7 @@ public class GlideEngine implements ImageEngine {
      * @param call      回调接口
      */
     @Override
-    public void loadImageBitmap(@NonNull Context context, @NonNull String url, int maxWidth, int maxHeight, OnCallbackListener<Bitmap> call) {
+    public void loadImageBitmap(@NonNull Context context, @NonNull String url, int maxWidth, int maxHeight, ImageView imageView,OnCallbackListener<Bitmap> call) {
         if (!ActivityCompatHelper.assertValidRequest(context)) {
             return;
         }

--- a/app/src/main/java/com/luck/pictureselector/PicassoEngine.java
+++ b/app/src/main/java/com/luck/pictureselector/PicassoEngine.java
@@ -64,7 +64,7 @@ public class PicassoEngine implements ImageEngine {
      * @param call      回调接口
      */
     @Override
-    public void loadImageBitmap(@NonNull Context context, @NonNull String url, int maxWidth, int maxHeight, OnCallbackListener<Bitmap> call) {
+    public void loadImageBitmap(@NonNull Context context, @NonNull String url, int maxWidth, int maxHeight, ImageView imageView, OnCallbackListener<Bitmap> call) {
         if (!ActivityCompatHelper.assertValidRequest(context)) {
             return;
         }

--- a/selector/src/main/java/com/luck/picture/lib/PictureSelectorPreviewFragment.java
+++ b/selector/src/main/java/com/luck/picture/lib/PictureSelectorPreviewFragment.java
@@ -1388,7 +1388,7 @@ public class PictureSelectorPreviewFragment extends PictureCommonFragment {
             setMagicalViewParams(size[0], size[1], position);
         } else {
             PictureSelectionConfig.imageEngine.loadImageBitmap(getActivity(), media.getAvailablePath(),
-                    maxImageSize[0], maxImageSize[1], new OnCallbackListener<Bitmap>() {
+                    maxImageSize[0], maxImageSize[1], null, new OnCallbackListener<Bitmap>() {
                         @Override
                         public void onCall(Bitmap bitmap) {
                             if (ActivityCompatHelper.isDestroy(getActivity())) {

--- a/selector/src/main/java/com/luck/picture/lib/adapter/holder/BasePreviewHolder.java
+++ b/selector/src/main/java/com/luck/picture/lib/adapter/holder/BasePreviewHolder.java
@@ -114,7 +114,7 @@ public class BasePreviewHolder extends RecyclerView.ViewHolder {
 
     protected void loadImageBitmap(final LocalMedia media, int maxWidth, int maxHeight) {
         if (PictureSelectionConfig.imageEngine != null) {
-            PictureSelectionConfig.imageEngine.loadImageBitmap(itemView.getContext(), media.getAvailablePath(), maxWidth, maxHeight,
+            PictureSelectionConfig.imageEngine.loadImageBitmap(itemView.getContext(), media.getAvailablePath(), maxWidth, maxHeight,coverImageView,
                     new OnCallbackListener<Bitmap>() {
                         @Override
                         public void onCall(Bitmap bitmap) {

--- a/selector/src/main/java/com/luck/picture/lib/engine/ImageEngine.java
+++ b/selector/src/main/java/com/luck/picture/lib/engine/ImageEngine.java
@@ -30,9 +30,10 @@ public interface ImageEngine {
      * @param url
      * @param maxWidth
      * @param maxHeight
+     * @param imageView
      * @param call
      */
-    void loadImageBitmap(@NonNull Context context, @NonNull String url, int maxWidth, int maxHeight,
+    void loadImageBitmap(@NonNull Context context, @NonNull String url, int maxWidth, int maxHeight,ImageView imageView,
                          OnCallbackListener<Bitmap> call);
 
     /**


### PR DESCRIPTION
查看大图加载照片的时候 开放容器photoview 方便外部设置它的触摸事件（包括touchListener 缩放比例  单击 双击等操作的响应）  用户可以在setImageEngine的时候获取到imageview 从而能设置图片的手势