### PR TITLE
增加属性回传图片是拍摄的还是原本就在相册中的

### DIFF
--- a/selector/src/main/java/com/luck/picture/lib/basic/PictureCommonFragment.java
+++ b/selector/src/main/java/com/luck/picture/lib/basic/PictureCommonFragment.java
@@ -1163,7 +1163,7 @@ public abstract class PictureCommonFragment extends Fragment implements IPicture
                 if (config.chooseMode == SelectMimeType.ofAudio()) {
                     copyOutputAudioToDir();
                 }
-                return buildLocalMedia(config.cameraPath);
+                return buildLocalMedia(config.cameraPath, true);
             }
 
             @Override
@@ -1257,10 +1257,12 @@ public abstract class PictureCommonFragment extends Fragment implements IPicture
      * buildLocalMedia
      *
      * @param absolutePath
+     * @param fromCamera
      */
-    protected LocalMedia buildLocalMedia(String absolutePath) {
+    protected LocalMedia buildLocalMedia(String absolutePath,boolean fromCamera) {
         LocalMedia media = LocalMedia.generateLocalMedia(getAppContext(), absolutePath);
         media.setChooseModel(config.chooseMode);
+        media.setFromCamera(fromCamera);
         if (SdkVersionUtils.isQ() && !PictureMimeType.isContent(absolutePath)) {
             media.setSandboxPath(absolutePath);
         } else {
@@ -1272,6 +1274,9 @@ public abstract class PictureCommonFragment extends Fragment implements IPicture
         return media;
     }
 
+    public LocalMedia buildLocalMedia(String absolutePath) {
+        return buildLocalMedia(absolutePath, false);
+    }
     /**
      * 验证完成选择的先决条件
      *

--- a/selector/src/main/java/com/luck/picture/lib/entity/LocalMedia.java
+++ b/selector/src/main/java/com/luck/picture/lib/entity/LocalMedia.java
@@ -194,6 +194,12 @@ public class LocalMedia implements Parcelable {
      */
     private boolean isEditorImage;
 
+    /**
+     * Whether the image or video is from the camera
+     * Only valid once
+     */
+    private boolean fromCamera = false;
+
     public LocalMedia() {
     }
 
@@ -232,6 +238,7 @@ public class LocalMedia implements Parcelable {
         isMaxSelectEnabledMask = in.readByte() != 0;
         isGalleryEnabledMask = in.readByte() != 0;
         isEditorImage = in.readByte() != 0;
+        fromCamera = in.readByte() != 0;
     }
 
     @Override
@@ -270,6 +277,7 @@ public class LocalMedia implements Parcelable {
         dest.writeByte((byte) (isMaxSelectEnabledMask ? 1 : 0));
         dest.writeByte((byte) (isGalleryEnabledMask ? 1 : 0));
         dest.writeByte((byte) (isEditorImage ? 1 : 0));
+        dest.writeByte((byte) (fromCamera ? 1 : 0));
     }
 
     @Override
@@ -720,6 +728,14 @@ public class LocalMedia implements Parcelable {
 
     public void setVideoThumbnailPath(String videoThumbnailPath) {
         this.videoThumbnailPath = videoThumbnailPath;
+    }
+
+    public boolean isFromCamera() {
+        return fromCamera;
+    }
+
+    public void setFromCamera(boolean fromCamera) {
+        this.fromCamera = fromCamera;
     }
 
     /**


### PR DESCRIPTION
LocalMedia add fromCamera field: Whether the image or video is from the camera,Single selection process takes effect,Invalid when you select the photo again 
https://github.com/LuckSiege/PictureSelector/issues/2588
