### PR TITLE
Update: make "obtainMediaData" method execute callback even when query result size is 0.

### DIFF
--- a/selector/src/main/java/com/luck/picture/lib/basic/PictureSelectionQueryModel.java
+++ b/selector/src/main/java/com/luck/picture/lib/basic/PictureSelectionQueryModel.java
@@ -253,7 +253,11 @@ public class PictureSelectionQueryModel {
         loader.loadAllAlbum(new OnQueryAllAlbumListener<LocalMediaFolder>() {
             @Override
             public void onComplete(List<LocalMediaFolder> result) {
-                if (result != null && result.size() > 0) {
+                if (result != null) {
+                    if (result.size() == 0) {
+                        call.onComplete(new ArrayList<>());
+                        return;
+                    }
                     LocalMediaFolder all = result.get(0);
                     if (selectionConfig.isPageStrategy) {
                         loader.loadPageMediaData(all.getBucketId(), 1, selectionConfig.pageSize,


### PR DESCRIPTION
I think `obtainAlbumData` method need execute execute callback even when query result size is 0. The reason is below:
1. query result size 0 is a correct condition.
2. sometimes I need show empty view and tips when size is 0. Due the callback dont execute when size 0，I cannot find right time to show empty tips for user.