### PR TITLE
targetSdkVersion 为安卓14时，优化安卓14上媒体重选逻辑（根据谷歌官方推荐写法）

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,11 +8,10 @@ static def releaseTime() {
 
 android {
     compileSdk 34
-
     defaultConfig {
         applicationId "com.luck.pictureselector"
-        minSdk 21
-        targetSdk 34
+        minSdkVersion 21
+        targetSdkVersion 34
         versionCode cfgs.versionCode
         versionName cfgs.versionName
     }
@@ -69,9 +68,11 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
+
+    namespace "com.luck.pictureselector"
 }
 
 dependencies {

--- a/app/src/main/res/layout/ps_custom_fragment_selector.xml
+++ b/app/src/main/res/layout/ps_custom_fragment_selector.xml
@@ -15,7 +15,7 @@
         app:layout_constraintBottom_toTopOf="@+id/bottom_nar_bar"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/title_bar" />
+        app:layout_constraintTop_toBottomOf="@+id/media_reselection_tip_view" />
 
     <TextView
         android:id="@+id/tv_current_data_time"
@@ -31,7 +31,7 @@
         android:textSize="12sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/title_bar" />
+        app:layout_constraintTop_toBottomOf="@+id/media_reselection_tip_view" />
 
     <com.luck.pictureselector.CustomTitleBar
         android:id="@+id/title_bar"
@@ -40,6 +40,16 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        tools:layout_height="48dp" />
+
+    <com.luck.picture.lib.widget.MediaReselectionTipView
+        android:id="@+id/media_reselection_tip_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/title_bar"
         tools:layout_height="48dp" />
 
     <com.luck.pictureselector.CustomBottomNavBar

--- a/build.gradle
+++ b/build.gradle
@@ -3,16 +3,22 @@ apply from: "config.gradle"
 
 buildscript {
     repositories {
-        google()
-        mavenCentral()
-        maven {
-            url 'https://maven.google.com/'
-            name 'Google'
+        google {
+            content {
+                includeGroupByRegex("com\\.android.*")
+                includeGroupByRegex("com\\.google.*")
+                includeGroupByRegex("androidx.*")
+            }
         }
+        mavenCentral()
+        gradlePluginPortal()
+        maven { url 'https://developer.huawei.com/repo/' } //华为 push
+        //mavenCentral仓和jcenter仓的聚合仓 阿里云镜像(老)
+        maven { url 'https://maven.aliyun.com/nexus/content/groups/public' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21'
+        classpath 'com.android.tools.build:gradle:8.10.1'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.21'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -21,12 +27,18 @@ buildscript {
 allprojects {
 
     repositories {
-        google()
-        mavenCentral()
-        maven {
-            url 'https://maven.google.com/'
-            name 'Google'
+        google {
+            content {
+                includeGroupByRegex("com\\.android.*")
+                includeGroupByRegex("com\\.google.*")
+                includeGroupByRegex("androidx.*")
+            }
         }
+        mavenCentral()
+        gradlePluginPortal()
+        maven { url 'https://developer.huawei.com/repo/' } //华为 push
+        //mavenCentral仓和jcenter仓的聚合仓 阿里云镜像(老)
+        maven { url 'https://maven.aliyun.com/nexus/content/groups/public' }
     }
 }
 

--- a/camerax/build.gradle
+++ b/camerax/build.gradle
@@ -3,11 +3,10 @@ plugins {
 }
 
 android {
-    compileSdkVersion 31
-
+    compileSdk 34
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion 34
 
         consumerProguardFiles "consumer-rules.pro"
     }
@@ -19,9 +18,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
+
+    namespace "com.luck.lib.camerax"
 }
 
 ext {

--- a/compress/build.gradle
+++ b/compress/build.gradle
@@ -2,7 +2,18 @@ apply plugin: 'com.android.library'
 
 buildscript {
     repositories {
-        jcenter()
+        google {
+            content {
+                includeGroupByRegex("com\\.android.*")
+                includeGroupByRegex("com\\.google.*")
+                includeGroupByRegex("androidx.*")
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+        maven { url 'https://developer.huawei.com/repo/' } //华为 push
+        //mavenCentral仓和jcenter仓的聚合仓 阿里云镜像(老)
+        maven { url 'https://maven.aliyun.com/nexus/content/groups/public' }
     }
     dependencies {
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
@@ -10,11 +21,10 @@ buildscript {
 }
 
 android {
-    compileSdkVersion 27
-
+    compileSdk 34
     defaultConfig {
-        minSdkVersion 14
-        targetSdkVersion 27
+        minSdkVersion 21
+        targetSdkVersion 34
     }
     buildTypes {
         release {
@@ -22,6 +32,8 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    namespace "top.zibin.luban"
 }
 
 ext {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,19 +1,34 @@
-# Project-wide Gradle settings.
-# IDE (e.g. Android Studio) users:
-# Gradle settings configured through the IDE *will override*
-# any settings specified in this file.
-# For more details on how to configure your build environment visit
+## For more details on how to configure your build environment visit
 # http://www.gradle.org/docs/current/userguide/build_environment.html
+#
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-# Default value: -Xmx10248m -XX:MaxPermSize=256m
+# Default value: -Xmx1024m -XX:MaxPermSize=256m
 # org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+#
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-
-android.useAndroidX=true
+#Tue Nov 22 14:42:20 CST 2022
+kotlin.code.style=official
 android.injected.testOnly=false
+org.gradle.jvmargs=-Xms6g -Xmx6g -Dkotlin.daemon.jvm.options\="-Xmx6g" -XX\:MaxMetaspaceSize=1g -XX\:+HeapDumpOnOutOfMemoryError -Dfile.encoding\=UTF-8 -XX\:+UseParallelGC
+android.useAndroidX=true
+android.enableJetifier=true
+#
+#--------- gradle 8.0 new properties -----------------
+#?????????????? module ?? BuildConfig ?????? false????????????????????? build.gradle ?????
+android.defaults.buildfeatures.buildconfig=true
+#????????R????????????? lib ?? R ???????????????? true?
+android.nonTransitiveRClass=false
+#??????? Java ????????????? true???? switch-case ????? id ??????? final ???
+android.nonFinalResIds=false
+#????????? false?? true ??BuildConfig ??????? Java ????????????????? Java ?????
+#android.enableBuildConfigAsBytecode=false
+# default true
+android.enableR8.fullMode=false
+# ksp ?? 2.0.0 ??????????? ksp2?epoxy-processor 5.1.4 ???????20250623?
+ksp.useKSP2=false
 
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://mirrors.cloud.tencent.com/gradle/gradle-8.11.1-bin.zip

--- a/ijkplayer-java/build.gradle
+++ b/ijkplayer-java/build.gradle
@@ -2,24 +2,25 @@ apply plugin: 'com.android.library'
 
 android {
     // http://tools.android.com/tech-docs/new-build-system/tips
-    //noinspection GroovyAssignabilityCheck
-    compileSdkVersion 30
-    //noinspection GroovyAssignabilityCheck
-    buildToolsVersion "30.0.3"
+
+    compileSdk 34
+    defaultConfig {
+        minSdkVersion 21
+        targetSdkVersion 34
+    }
 
     lintOptions {
         abortOnError false
     }
-    defaultConfig {
-        minSdkVersion 9
-        targetSdkVersion 30
-    }
+
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    namespace 'tv.danmaku.ijk.media.player'
 }
 
 dependencies {

--- a/selector/build.gradle
+++ b/selector/build.gradle
@@ -2,17 +2,16 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdk 34
-
     defaultConfig {
-        minSdk 19
-        targetSdk 34
+        minSdkVersion 21
+        targetSdkVersion 34
 
         vectorDrawables.useSupportLibrary = true
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     buildTypes {
@@ -24,6 +23,8 @@ android {
     lintOptions {
         abortOnError false
     }
+
+    namespace "com.luck.picture.lib"
 }
 
 ext {

--- a/selector/src/main/java/com/luck/picture/lib/PictureSelectorFragment.java
+++ b/selector/src/main/java/com/luck/picture/lib/PictureSelectorFragment.java
@@ -248,7 +248,6 @@ public class PictureSelectorFragment extends PictureCommonFragment
         onCreateLoader();
         initAlbumListPopWindow();
         initTitleBar();
-        initMediaReselectionTipView(false);
         initComplete();
         initRecycler(view);
         initBottomNavBar();
@@ -433,29 +432,11 @@ public class PictureSelectorFragment extends PictureCommonFragment
         if (PermissionChecker.isCheckReadStorage(selectorConfig.chooseMode, getContext())) {
             beginLoadData();
         } else if (PermissionChecker.isCheckUserSelected(selectorConfig.chooseMode, getContext())) {
-            //权限未授予，但是授予了 READ_MEDIA_VISUAL_USER_SELECTED 权限
-            //正常加载数据，同时提示用户再次选择要展示在图库的照片
-            initMediaReselectionTipView(true);
+            //媒体权限未授予，但是授予了 READ_MEDIA_VISUAL_USER_SELECTED 权限
+            //正常加载数据
             beginLoadData();
         } else {
             requestPermissionsAndLoadData();
-        }
-    }
-
-    private void initMediaReselectionTipView(Boolean showTip) {
-        if (showTip) {
-            mediaReselectionTipView.setVisibility(View.VISIBLE);
-            mediaReselectionTipView.setMediaReselectionTipViewStyle();
-            mediaReselectionTipView.setOnMediaReselectionListener(
-                    new MediaReselectionTipView.OnMediaReselectionListener() {
-                        @Override
-                        public void onManageClick() {
-                            requestPermissionsAndLoadData();
-                        }
-                    }
-            );
-        } else {
-            mediaReselectionTipView.setVisibility(View.GONE);
         }
     }
 
@@ -501,11 +482,33 @@ public class PictureSelectorFragment extends PictureCommonFragment
      * 开始获取数据
      */
     private void beginLoadData() {
+        //加载数据同时，初始化媒体重选 View
+        initMediaReselectionTipView();
         onPermissionExplainEvent(false, null);
         if (selectorConfig.isOnlySandboxDir) {
             loadOnlyInAppDirectoryAllMediaData();
         } else {
             loadAllAlbumData();
+        }
+    }
+
+    private void initMediaReselectionTipView() {
+        //未授予读写权限 且 授予 READ_MEDIA_VISUAL_USER_SELECTED 权限，需要显示媒体重选提示
+        boolean shouldShowMediaReselectionTip = !PermissionChecker.isCheckReadStorage(selectorConfig.chooseMode, getContext())
+                && PermissionChecker.isCheckUserSelected(selectorConfig.chooseMode, getContext());
+        if (shouldShowMediaReselectionTip) {
+            mediaReselectionTipView.setVisibility(View.VISIBLE);
+            mediaReselectionTipView.setMediaReselectionTipViewStyle();
+            mediaReselectionTipView.setOnMediaReselectionListener(
+                    new MediaReselectionTipView.OnMediaReselectionListener() {
+                        @Override
+                        public void onManageClick() {
+                            requestPermissionsAndLoadData();
+                        }
+                    }
+            );
+        } else {
+            mediaReselectionTipView.setVisibility(View.GONE);
         }
     }
 

--- a/selector/src/main/java/com/luck/picture/lib/permissions/PermissionChecker.java
+++ b/selector/src/main/java/com/luck/picture/lib/permissions/PermissionChecker.java
@@ -91,7 +91,7 @@ public class PermissionChecker {
         }
     }
 
-    public void onRequestPermissionsResult(Context context,String[] permissions,int[] grantResults, PermissionResultCallback action) {
+    public void onRequestPermissionsResult(Context context, String[] permissions, int[] grantResults, PermissionResultCallback action) {
         Activity activity = (Activity) context;
         for (String permission : permissions) {
             boolean should = ActivityCompat.shouldShowRequestPermissionRationale(activity, permission);
@@ -143,6 +143,19 @@ public class PermissionChecker {
         }
     }
 
+    /**
+     * 检查 READ_MEDIA_VISUAL_USER_SELECTED 权限是否存在
+     */
+    public static boolean isCheckUserSelected(int chooseMode, Context context) {
+        if (SdkVersionUtils.isUPSIDE_DOWN_CAKE()) {
+            if (chooseMode != SelectMimeType.ofAudio()) {
+                return PermissionChecker.checkSelfPermission(context,
+                        new String[]{PermissionConfig.READ_MEDIA_VISUAL_USER_SELECTED});
+            } else return false;
+        } else {
+            return false;
+        }
+    }
 
     /**
      * 检查读取图片权限是否存在

--- a/selector/src/main/java/com/luck/picture/lib/widget/MediaReselectionTipView.java
+++ b/selector/src/main/java/com/luck/picture/lib/widget/MediaReselectionTipView.java
@@ -1,0 +1,124 @@
+package com.luck.picture.lib.widget;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.FrameLayout;
+import android.widget.TextView;
+
+import androidx.constraintlayout.widget.ConstraintLayout;
+import androidx.core.content.ContextCompat;
+
+import com.luck.picture.lib.R;
+import com.luck.picture.lib.config.SelectorConfig;
+import com.luck.picture.lib.config.SelectorProviders;
+import com.luck.picture.lib.style.BottomNavBarStyle;
+import com.luck.picture.lib.style.PictureSelectorStyle;
+import com.luck.picture.lib.utils.StyleUtils;
+
+/**
+ * Created on 2024/1/17.
+ *
+ * @author wdeo3601@163.com
+ * @description 安卓34+，READ_MEDIA_VISUAL_USER_SELECTED 授权后,提示用户重选媒体
+ */
+public class MediaReselectionTipView extends FrameLayout implements View.OnClickListener {
+
+    protected TextView tvTip;
+    protected TextView tvManage;
+    protected SelectorConfig config;
+    protected ConstraintLayout mediaReselectionTipLayout;
+
+    public TextView getTitleManageView() {
+        return tvManage;
+    }
+
+    public MediaReselectionTipView(Context context) {
+        super(context);
+        init();
+    }
+
+    public MediaReselectionTipView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        init();
+    }
+
+    public MediaReselectionTipView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        init();
+    }
+
+    protected void init() {
+        inflateLayout();
+        setClickable(true);
+        setFocusable(true);
+        config = SelectorProviders.getInstance().getSelectorConfig();
+        mediaReselectionTipLayout = findViewById(R.id.cl_media_reselection_tip);
+        tvTip = findViewById(R.id.ps_tv_title);
+        tvManage = findViewById(R.id.ps_tv_manage);
+        tvManage.setOnClickListener(this);
+        mediaReselectionTipLayout.setOnClickListener(this);
+        setBackgroundColor(ContextCompat.getColor(getContext(), R.color.ps_color_grey));
+        handleLayoutUI();
+    }
+
+    protected void inflateLayout() {
+        LayoutInflater.from(getContext()).inflate(R.layout.ps_media_reselection_tip_view, this);
+    }
+
+    protected void handleLayoutUI() {
+
+    }
+
+    public void setMediaReselectionTipViewStyle() {
+        PictureSelectorStyle selectorStyle = config.selectorStyle;
+        BottomNavBarStyle bottomBarStyle = selectorStyle.getBottomBarStyle();
+
+        int backgroundColor = bottomBarStyle.getBottomNarBarBackgroundColor();
+        if (StyleUtils.checkStyleValidity(backgroundColor)) {
+            setBackgroundColor(backgroundColor);
+        }
+
+        int previewNormalTextColor = bottomBarStyle.getBottomPreviewNormalTextColor();
+        if (StyleUtils.checkSizeValidity(previewNormalTextColor)) {
+            tvTip.setTextColor(previewNormalTextColor);
+        }
+
+        int previewSelectTextColor = bottomBarStyle.getBottomPreviewSelectTextColor();
+        if (StyleUtils.checkStyleValidity(previewSelectTextColor)) {
+            tvManage.setTextColor(previewSelectTextColor);
+        }
+        int previewNormalTextSize = bottomBarStyle.getBottomPreviewNormalTextSize();
+        if (StyleUtils.checkSizeValidity(previewNormalTextSize)) {
+            tvManage.setTextSize(previewNormalTextSize);
+        }
+    }
+
+    @Override
+    public void onClick(View view) {
+        int id = view.getId();
+        if (id == R.id.ps_tv_manage) {
+            if (mediaReselectionListener != null) {
+                mediaReselectionListener.onManageClick();
+            }
+        }
+    }
+
+    protected OnMediaReselectionListener mediaReselectionListener;
+
+    /**
+     * 功能事件回调
+     *
+     * @param listener
+     */
+    public void setOnMediaReselectionListener(OnMediaReselectionListener listener) {
+        this.mediaReselectionListener = listener;
+    }
+
+    public static class OnMediaReselectionListener {
+        public void onManageClick() {
+
+        }
+    }
+}

--- a/selector/src/main/res/layout/ps_fragment_selector.xml
+++ b/selector/src/main/res/layout/ps_fragment_selector.xml
@@ -13,7 +13,7 @@
         app:layout_constraintBottom_toTopOf="@+id/bottom_nar_bar"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/title_bar" />
+        app:layout_constraintTop_toBottomOf="@+id/media_reselection_tip_view" />
 
     <com.luck.picture.lib.widget.MediumBoldTextView
         android:id="@+id/tv_current_data_time"
@@ -29,7 +29,7 @@
         android:textSize="12sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/title_bar" />
+        app:layout_constraintTop_toBottomOf="@+id/media_reselection_tip_view" />
 
     <com.luck.picture.lib.widget.TitleBar
         android:id="@+id/title_bar"
@@ -38,6 +38,16 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        tools:layout_height="48dp" />
+
+    <com.luck.picture.lib.widget.MediaReselectionTipView
+        android:id="@+id/media_reselection_tip_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/title_bar"
         tools:layout_height="48dp" />
 
     <com.luck.picture.lib.widget.BottomNavBar
@@ -54,9 +64,9 @@
         android:id="@+id/ps_complete_select"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:enabled="false"
         android:layout_marginEnd="15dp"
         android:background="@drawable/ps_transparent_space"
+        android:enabled="false"
         app:layout_constraintBottom_toBottomOf="@id/bottom_nar_bar"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="@id/bottom_nar_bar" />

--- a/selector/src/main/res/layout/ps_media_reselection_tip_view.xml
+++ b/selector/src/main/res/layout/ps_media_reselection_tip_view.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/cl_media_reselection_tip"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingTop="10dp"
+        android:paddingBottom="10dp">
+
+        <TextView
+            android:id="@+id/ps_tv_tip"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="15dp"
+            android:text="@string/ps_media_reselection_tip"
+            android:textColor="@color/ps_color_9b"
+            android:textSize="12sp"
+            app:layout_constrainedWidth="true"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/ps_tv_manage"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/ps_tv_manage"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:paddingStart="15dp"
+            android:paddingEnd="15dp"
+            android:text="@string/ps_manage"
+            android:textColor="@color/ps_color_white"
+            android:textSize="14sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</merge>

--- a/selector/src/main/res/values-ar-rAE/strings.xml
+++ b/selector/src/main/res/values-ar-rAE/strings.xml
@@ -75,4 +75,6 @@
     <string name="ps_select_audio_max_second">ختيار الصوت أكبر من %1$d ثانية</string>
     <string name="ps_select_audio_min_second">اختيار الصوت أقل من %1$d ثوان</string>
     <string name="ps_select_no_support">اختيار نوع غير معتمد</string>
+    <string name="ps_manage"> إدارة </string>
+    <string name="ps_media_reselection_tip">لقد منحت حق الوصول إلى عدد محدد من الصور ومقاطع الفيديو.</string>
 </resources>

--- a/selector/src/main/res/values-cs-rCZ/string.xml
+++ b/selector/src/main/res/values-cs-rCZ/string.xml
@@ -79,4 +79,6 @@
     <string name="ps_select_audio_max_second">Vyberte zvuk delší než %1$d s</string>
     <string name="ps_select_audio_min_second">Vyberte zvuk kratší než %1$d s</string>
     <string name="ps_select_no_support">Nepodporovaný typ výběru</string>
+    <string name="ps_manage">Podávání</string>
+    <string name="ps_media_reselection_tip">udělili jste přístup k vybranému počtu fotografií a videí.</string>
 </resources>

--- a/selector/src/main/res/values-de-rDE/strings.xml
+++ b/selector/src/main/res/values-de-rDE/strings.xml
@@ -75,4 +75,6 @@
     <string name="ps_select_audio_max_second">Audio für mehr als %1$d Sekunden auswählen</string>
     <string name="ps_select_audio_min_second">Audio für weniger als %1$d Sekunden auswählen</string>
     <string name="ps_select_no_support">Nicht unterstützter Auswahltyp</string>
+    <string name="ps_manage">Verwaltung</string>
+    <string name="ps_media_reselection_tip">Sie haben Zugriff auf eine ausgewählte Anzahl von Fotos und Videos gewährt.</string>
 </resources>

--- a/selector/src/main/res/values-en-rUS/string.xml
+++ b/selector/src/main/res/values-en-rUS/string.xml
@@ -78,4 +78,6 @@
     <string name="ps_select_audio_max_second">Select audio for more than %1$d s</string>
     <string name="ps_select_audio_min_second">Select audio for less than %1$d s</string>
     <string name="ps_select_no_support">Unsupported selection type</string>
+    <string name="ps_manage">Manage</string>
+    <string name="ps_media_reselection_tip">you\'ve given access to a select number of photos and videos.</string>
 </resources>

--- a/selector/src/main/res/values-es-rES/strings.xml
+++ b/selector/src/main/res/values-es-rES/strings.xml
@@ -76,4 +76,6 @@
     <string name="ps_select_audio_max_second">Seleccionar audio durante más de %1$d segundos</string>
     <string name="ps_select_audio_min_second">Seleccionar audio durante menos de %1$d segundos</string>
     <string name="ps_select_no_support">Tipos de selección no soportados</string>
+    <string name="ps_manage">administrar</string>
+    <string name="ps_media_reselection_tip">le has dado acceso a un número selecto de fotos y videos.</string>
 </resources>

--- a/selector/src/main/res/values-fr-rFR/strings.xml
+++ b/selector/src/main/res/values-fr-rFR/strings.xml
@@ -75,4 +75,6 @@
     <string name="ps_select_audio_max_second">Sélectionnez audio plus de %1$d secondes</string>
     <string name="ps_select_audio_min_second">Sélectionnez audio moins de %1$d secondes</string>
     <string name="ps_select_no_support">Type de sélection non pris en charge</string>
+    <string name="ps_manage">Gestion</string>
+    <string name="ps_media_reselection_tip">vous avez donné accès à un certain nombre de photos et de vidéos.</string>
 </resources>

--- a/selector/src/main/res/values-ja-rJP/strings.xml
+++ b/selector/src/main/res/values-ja-rJP/strings.xml
@@ -75,4 +75,6 @@
     <string name="ps_select_audio_max_second">%1$d秒以上のオーディオを選択</string>
     <string name="ps_select_audio_min_second">%1$d秒未満のオーディオを選択</string>
     <string name="ps_select_no_support">サポートされていない選択タイプ</string>
+    <string name="ps_manage">管理</string>
+    <string name="ps_media_reselection_tip">選択した数の写真とビデオへのアクセスが許可されました。</string>
 </resources>

--- a/selector/src/main/res/values-kk-rKZ/string.xml
+++ b/selector/src/main/res/values-kk-rKZ/string.xml
@@ -79,4 +79,6 @@
     <string name="ps_select_audio_max_second">%1$d секундан артық аудионы таңдау</string>
     <string name="ps_select_audio_min_second">%1$d секундан аз аудионы таңдау</string>
     <string name="ps_select_no_support">Таңдау типі қолдау көрсетілмейді</string>
+    <string name="ps_manage">басқару</string>
+    <string name="ps_media_reselection_tip">фотосуреттер мен бейнелердің таңдаулы санына рұқсат бердіңіз.</string>
 </resources>

--- a/selector/src/main/res/values-ko-rKR/strings.xml
+++ b/selector/src/main/res/values-ko-rKR/strings.xml
@@ -75,4 +75,6 @@
     <string name="ps_select_audio_max_second">%1$d초 이상의 음성파일을 선택해주세요.</string>
     <string name="ps_select_audio_min_second">%1$d초 미만의 음성파일을 선택해주세요.</string>
     <string name="ps_select_no_support">지원되지 않는 선택 유형입니다.</string>
+    <string name="ps_manage">관리하다</string>
+    <string name="ps_media_reselection_tip">선택한 수의 사진과 비디오에 대한 액세스 권한을 부여했습니다.</string>
 </resources>

--- a/selector/src/main/res/values-pt-rPT/strings.xml
+++ b/selector/src/main/res/values-pt-rPT/strings.xml
@@ -76,4 +76,6 @@
     <string name="ps_select_audio_max_second">Selecionar áudio por mais de %1$d segundos</string>
     <string name="ps_select_audio_min_second">Selecionar áudio por menos de %1$d segundos</string>
     <string name="ps_select_no_support">Tipo de selecção não suportado</string>
+    <string name="ps_manage">gerenciar</string>
+    <string name="ps_media_reselection_tip">você deu acesso a um número selecionado de fotos e vídeos.</string>
 </resources>

--- a/selector/src/main/res/values-ru-rRU/strings.xml
+++ b/selector/src/main/res/values-ru-rRU/strings.xml
@@ -75,4 +75,6 @@
     <string name="ps_select_audio_max_second">Выберите звук больше %1$d секунд</string>
     <string name="ps_select_audio_min_second">Выберите звук меньше %1$d секунд</string>
     <string name="ps_select_no_support">не поддерживается тип выделения</string>
+    <string name="ps_manage">управлять</string>
+    <string name="ps_media_reselection_tip">вы предоставили доступ к определенному количеству фотографий и видео.</string>
 </resources>

--- a/selector/src/main/res/values-vi-rVN/string.xml
+++ b/selector/src/main/res/values-vi-rVN/string.xml
@@ -76,4 +76,6 @@
     <string name="ps_select_audio_max_second">Chọn tiếng lớn hơn %1$d giây</string>
     <string name="ps_select_audio_min_second">Chọn tiếng dưới %1$d giây</string>
     <string name="ps_select_no_support">Kiểu chọn không được sắp xếp</string>
+    <string name="ps_manage">quản lý</string>
+    <string name="ps_media_reselection_tip">bạn đã cấp quyền truy cập vào một số ảnh và video được chọn.</string>
 </resources>

--- a/selector/src/main/res/values-zh-rCN/strings.xml
+++ b/selector/src/main/res/values-zh-rCN/strings.xml
@@ -75,4 +75,6 @@
     <string name="ps_select_audio_max_second">选择音频大于%1$d秒</string>
     <string name="ps_select_audio_min_second">选择音频小于%1$d秒</string>
     <string name="ps_select_no_support">不支持的选择类型</string>
+    <string name="ps_manage">管理</string>
+    <string name="ps_media_reselection_tip">您已授予对选定数量的照片和视频的访问权限。</string>
 </resources>

--- a/selector/src/main/res/values-zh-rTW/strings.xml
+++ b/selector/src/main/res/values-zh-rTW/strings.xml
@@ -75,4 +75,6 @@
     <string name="ps_select_audio_max_second">選擇錄音大於%1$d秒</string>
     <string name="ps_select_audio_min_second">選擇錄音小於%1$d秒</string>
     <string name="ps_select_no_support">不支援的選擇類型</string>
+    <string name="ps_manage">管理</string>
+    <string name="ps_media_reselection_tip">您已授予對選定數量的照片和影片的存取權。</string>
 </resources>

--- a/selector/src/main/res/values/strings.xml
+++ b/selector/src/main/res/values/strings.xml
@@ -75,4 +75,6 @@
     <string name="ps_select_audio_max_second">选择音频大于%1$d秒</string>
     <string name="ps_select_audio_min_second">选择音频小于%1$d秒</string>
     <string name="ps_select_no_support">不支持的选择类型</string>
+    <string name="ps_media_reselection_tip">您已授予对选定数量的照片和视频的访问权限。</string>
+    <string name="ps_manage">管理</string>
 </resources>

--- a/ucrop/build.gradle
+++ b/ucrop/build.gradle
@@ -1,11 +1,10 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 29
-
+    compileSdk 34
     defaultConfig {
-        minSdkVersion 19
-        targetSdkVersion 29
+        minSdkVersion 21
+        targetSdkVersion 34
         vectorDrawables.useSupportLibrary = true
     }
     buildTypes {
@@ -15,15 +14,17 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
+
     lintOptions {
         abortOnError false
     }
 
     resourcePrefix 'ucrop_'
 
+    namespace 'com.yalantis.ucrop'
 }
 
 ext {


### PR DESCRIPTION
安卓14设备上，如果媒体授权时用户选了`选择部分照片和视频`选项的话，之后每次进入相册，都会无提示自动弹出系统的`选择允许此应用访问的照片和视频`弹窗。这个逻辑对用户来说不太友好，查了谷歌官方文档，官方推荐在`无媒体授权且有READ_MEDIA_VISUAL_USER_SELECTED授权`时，提示用户，让用户去选择是否重选媒体文件。  
官方文档：https://developer.android.google.cn/about/versions/14/changes/partial-photo-video-access?hl=zh-cn#media-reselection  
![image](https://github.com/LuckSiege/PictureSelector/assets/22436965/bc48ab45-0664-4d9a-af79-9cf791ff9c62)  
我做的修改：  
1. 创建自定义 View `MediaReselectionTipView`，用于安卓14上的媒体重选提示  
2. 媒体重选提示文案国际化适配  
3. 修改 `PictureSelectorFragment` 中权限判断相关逻辑，细化出需要处理媒体重选的情况并处理  

一些情况说明：  
1. `MediaReselectionTipView`的样式配置使用了 `BottomNavBarStyle` 中背景色、预览正常字体颜色、预览选中字体颜色、预览正常字体大小  
2. 由于 `ps_fragment_selector.xml` 布局中新加了 `MediaReselectionTipView`，有自己自定义布局的，需要在自己的布局中合适位置加入  MediaReselectionTipView，否则会报错NPE  

demo 中各样式效果：  
![image](https://github.com/LuckSiege/PictureSelector/assets/22436965/74651460-dcaa-46ea-ad0b-f4ebed1e910d)
![image](https://github.com/LuckSiege/PictureSelector/assets/22436965/329ffd90-f722-4729-bd53-163a32b778d9)
