### PR TITLE
修复滑动多选时从底部往上滑选中顺序错误

### DIFF
--- a/selector/src/main/java/com/luck/picture/lib/widget/SlideSelectTouchListener.java
+++ b/selector/src/main/java/com/luck/picture/lib/widget/SlideSelectTouchListener.java
@@ -307,6 +307,8 @@ public class SlideSelectTouchListener implements RecyclerView.OnItemTouchListene
             return;
         }
 
+        boolean isReverse = mStart > mEnd;
+
         int newStart, newEnd;
         newStart = Math.min(mStart, mEnd);
         newEnd = Math.max(mStart, mEnd);
@@ -315,21 +317,21 @@ public class SlideSelectTouchListener implements RecyclerView.OnItemTouchListene
         }
         if (mLastStart == RecyclerView.NO_POSITION || mLastEnd == RecyclerView.NO_POSITION) {
             if (newEnd - newStart == 1) {
-                mSelectListener.onSelectChange(newStart, newStart, true);
+                mSelectListener.onSelectChange(newStart, newStart, true, isReverse);
             } else {
-                mSelectListener.onSelectChange(newStart, newEnd, true);
+                mSelectListener.onSelectChange(newStart, newEnd, true, isReverse);
             }
         } else {
             if (newStart > mLastStart) {
-                mSelectListener.onSelectChange(mLastStart, newStart - 1, false);
+                mSelectListener.onSelectChange(mLastStart, newStart - 1, false, isReverse);
             } else if (newStart < mLastStart) {
-                mSelectListener.onSelectChange(newStart, mLastStart - 1, true);
+                mSelectListener.onSelectChange(newStart, mLastStart - 1, true, isReverse);
             }
 
             if (newEnd > mLastEnd) {
-                mSelectListener.onSelectChange(mLastEnd + 1, newEnd, true);
+                mSelectListener.onSelectChange(mLastEnd + 1, newEnd, true, isReverse);
             } else if (newEnd < mLastEnd) {
-                mSelectListener.onSelectChange(newEnd + 1, mLastEnd, false);
+                mSelectListener.onSelectChange(newEnd + 1, mLastEnd, false, isReverse);
             }
         }
 
@@ -389,7 +391,8 @@ public class SlideSelectTouchListener implements RecyclerView.OnItemTouchListene
          * @param start      the newly (un)selected range start
          * @param end        the newly (un)selected range end
          * @param isSelected true, it range got selected, false if not
+         * @param isReverse  true, it select from bottom to top, false if not
          */
-        void onSelectChange(int start, int end, boolean isSelected);
+        void onSelectChange(int start, int end, boolean isSelected, boolean isReverse);
     }
 }

--- a/selector/src/main/java/com/luck/picture/lib/widget/SlideSelectionHandler.java
+++ b/selector/src/main/java/com/luck/picture/lib/widget/SlideSelectionHandler.java
@@ -54,9 +54,16 @@ public class SlideSelectionHandler implements SlideSelectTouchListener.OnAdvance
     }
 
     @Override
-    public void onSelectChange(int start, int end, boolean isSelected) {
-        for (int i = start; i <= end; i++) {
-            checkedChangeSelection(i, i, isSelected != mOriginalSelection.contains(i));
+    public void onSelectChange(int start, int end, boolean isSelected, boolean isReverse) {
+        if (isReverse) {
+            for (int i = end; i >= start; i--) {
+                checkedChangeSelection(i, i, isSelected != mOriginalSelection.contains(i));
+            }
+        }
+        else {
+            for (int i = start; i <= end; i++) {
+                checkedChangeSelection(i, i, isSelected != mOriginalSelection.contains(i));
+            }
         }
     }
 


### PR DESCRIPTION
开启滑动多选时，如果从底部往上滑动选择，选中顺序会出现“随机选中”而非如同从顶部向下滑动一样的按顺序选中，如图所示（注意看选中序号）：

![before](https://github.com/LuckSiege/PictureSelector/assets/6501123/a8c47e27-1a0c-4448-a333-2f5a768202f3)


这个 PR 修复了这个问题，如果是从底部往上滑动时会按照顺序倒序依次选中图片，如图所示：

![after](https://github.com/LuckSiege/PictureSelector/assets/6501123/2fd35030-51a1-47c0-b5f8-719e859cb3be)
