### PR TITLE
fix [支持可选地始终显示设置的默认标题栏文字选项]

### DIFF
--- a/selector/src/main/java/com/luck/picture/lib/style/TitleBarStyle.java
+++ b/selector/src/main/java/com/luck/picture/lib/style/TitleBarStyle.java
@@ -21,6 +21,11 @@ public class TitleBarStyle {
     private int previewTitleLeftBackResource;
 
     /**
+     * 标题栏是否始终显示默认文案
+     */
+    private boolean titleDefaultTextAlways;
+
+    /**
      * 标题栏默认文案
      */
     private String titleDefaultText;
@@ -141,6 +146,14 @@ public class TitleBarStyle {
 
     public void setPreviewTitleLeftBackResource(int previewTitleLeftBackResource) {
         this.previewTitleLeftBackResource = previewTitleLeftBackResource;
+    }
+
+    public boolean isTitleDefaultTextAlways() {
+        return titleDefaultTextAlways;
+    }
+
+    public void setTitleDefaultTextAlways(boolean titleDefaultTextAlways) {
+        this.titleDefaultTextAlways = titleDefaultTextAlways;
     }
 
     public String getTitleDefaultText() {

--- a/selector/src/main/java/com/luck/picture/lib/widget/TitleBar.java
+++ b/selector/src/main/java/com/luck/picture/lib/widget/TitleBar.java
@@ -119,6 +119,10 @@ public class TitleBar extends RelativeLayout implements View.OnClickListener {
      * @param title
      */
     public void setTitle(String title) {
+        if (config.selectorStyle.getTitleBarStyle().isTitleDefaultTextAlways()){
+            return;
+        }
+
         tvTitle.setText(title);
     }
 


### PR DESCRIPTION
场景说明：开启sandboxDir只显示一个目录下的文件时，并不希望标题是目录的名称，而是指定的固定标题文字。